### PR TITLE
fix(client): SEARCH panics if index and no payload

### DIFF
--- a/pkg/client/evaluator.go
+++ b/pkg/client/evaluator.go
@@ -122,9 +122,13 @@ func (c *commandEvaluator) evalShowStatement(q *vql.ShowStatement) vtp.Message {
 func (c *commandEvaluator) evalSearchStatement(node *vql.SearchStatement) vtp.Message {
 	var index string
 	var engine search.EngineType
+	if node.Payload == nil {
+		log.Println("SEARCH command requires a payload")
+		return nil
+	}
 	if node.Index == nil {
 		if c.env.Index == nil {
-			log.Println("SEARCH command requires a payload")
+			log.Println("Index not given, USE it first or provide it")
 			return nil
 		}
 		index = *c.env.Index


### PR DESCRIPTION
Running the SEARCH command with no additional arguments after an index
has been set using the INDEX command previously results in a panic.

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x5658d4]

    goroutine 1 [running]:
    github.com/sonirico/visigoth/pkg/client.(*commandEvaluator).evalSearchStatement(0xc0000a0ea0, 0xc000094910, 0x58c080, 0x5f2a00)
            /usr/home/danirod/v2/pkg/client/evaluator.go:157 +0x94
    github.com/sonirico/visigoth/pkg/client.(*commandEvaluator).evalStatement(0xc0000a0ea0, 0x5f19f0, 0xc000094910, 0x5f19f0, 0xc000094910)
            /usr/home/danirod/v2/pkg/client/evaluator.go:62 +0x225
    github.com/sonirico/visigoth/pkg/client.(*commandEvaluator).Eval(0xc0000a0ea0, 0xc0000be6e0, 0x6, 0x0, 0xc00010e021, 0x6)
            /usr/home/danirod/v2/pkg/client/evaluator.go:52 +0x16c
    github.com/sonirico/visigoth/pkg/client.(*CmdClient).eval(0xc0000b01c8, 0xc0000be6e0, 0x6)
            /usr/home/danirod/v2/pkg/client/cmd_client.go:48 +0x4d
    github.com/sonirico/visigoth/pkg/client.(*CmdClient).Repl(0xc0000b01c8, 0x5f1060, 0xc0000c8000, 0x5f1080, 0xc0000c8008)
            /usr/home/danirod/v2/pkg/client/cmd_client.go:79 +0x198
    main.main()
            /usr/home/danirod/v2/cmd/cmd_client.go:36 +0x77
    exit status 2
    *** Error code 1

    Stop.

After further inspection with a popular command line debugger, I believe
that the issue is being caused because of the wrong variable being
tested?